### PR TITLE
bugfix: filter out v2 markets

### DIFF
--- a/src/pages/borrower/hooks/useMarketsForBorrower.ts
+++ b/src/pages/borrower/hooks/useMarketsForBorrower.ts
@@ -47,13 +47,15 @@ export function useMarketsForBorrowerQuery({
     })
 
     return (
-      result.data.markets.map((market) =>
-        Market.fromSubgraphMarketData(
-          TargetChainId,
-          provider as SignerOrProvider,
-          market,
-        ),
-      ) ?? []
+      result.data.markets
+        .filter((m) => !!m.controller)
+        .map((market) =>
+          Market.fromSubgraphMarketData(
+            TargetChainId,
+            provider as SignerOrProvider,
+            market,
+          ),
+        ) ?? []
     )
   }
 
@@ -70,13 +72,15 @@ export function useMarketsForBorrowerQuery({
     const controller = result.data.controllers[0]
     if (controller) {
       return (
-        controller.markets.map((market) =>
-          Market.fromSubgraphMarketData(
-            TargetChainId,
-            provider as SignerOrProvider,
-            market,
-          ),
-        ) ?? []
+        controller.markets
+          .filter((m) => !!m.controller)
+          .map((market) =>
+            Market.fromSubgraphMarketData(
+              TargetChainId,
+              provider as SignerOrProvider,
+              market,
+            ),
+          ) ?? []
       )
     }
 

--- a/src/pages/lenders/LenderMarketsList/hooks/useLendersMarkets.ts
+++ b/src/pages/lenders/LenderMarketsList/hooks/useLendersMarkets.ts
@@ -73,16 +73,19 @@ export function useLendersMarkets({
       fetchPolicy: "network-only",
     })
     const authorizedMarkets = controllerAuthorizations
+      .filter((auth) => !!auth.controller)
       .map((auth) => auth.controller.markets)
       .flat()
-    const markets = _markets.map((market) =>
-      Market.fromSubgraphMarketData(
-        TargetChainId,
-        signerOrProvider as SignerOrProvider,
-        market,
-        address,
-      ),
-    )
+    const markets = _markets
+      .filter((market) => !!market.controller)
+      .map((market) =>
+        Market.fromSubgraphMarketData(
+          TargetChainId,
+          signerOrProvider as SignerOrProvider,
+          market,
+          address,
+        ),
+      )
     const lenderAccounts = markets.map((market) => {
       const lenderAccount = _lenderAccounts.find(
         (account) =>


### PR DESCRIPTION
Update `useLendersMarkets` and `useMarketsForBorrower` to filter out V2 markets.