### PR TITLE
reworking connection modal to be more responsive

### DIFF
--- a/src/components/Header/ConnectButton/index.tsx
+++ b/src/components/Header/ConnectButton/index.tsx
@@ -143,7 +143,7 @@ function ConnectButton() {
                       <div className="flex items-center justify-center h-full flex-col gap-2 px-4 sm:px-6 pb-3 md:py-2 overflow-y-auto max-h-[60vh]">
                         {isConnected && isWrongNetwork && (
                           <Button
-                            variant="silver"
+                            variant="black"
                             className="w-full"
                             onClick={() => switchNetwork?.(TargetChainId)}
                           >

--- a/src/components/Header/ConnectButton/index.tsx
+++ b/src/components/Header/ConnectButton/index.tsx
@@ -96,7 +96,7 @@ function ConnectButton() {
       <Button className="rounded-sm" onClick={openModal} variant="silver">
         <div className="flex items-center gap-2">
           <span className="text-black text-xs">{getButtonText()}</span>
-          <RiWallet3Line className="w-5" />
+          <RiWallet3Line className="w-4 h-4" />
         </div>
       </Button>
       <Transition appear show={isOpen} as={Fragment}>
@@ -128,25 +128,22 @@ function ConnectButton() {
                 leaveFrom="opacity-100 scale-100"
                 leaveTo="opacity-0 scale-95"
               >
-                <Dialog.Panel className="transform transition-all w-full">
+                <Dialog.Panel className="transform transition-all w-full max-w-sm sm:max-w-sm md:max-w-md lg:max-w-[24rem]">
                   <div className="flex flex-col items-center">
-                    <Paper
-                      className="bg-sand p-2 rounded-sm"
-                      style={{ width: "20vw" }}
-                    >
+                    <Paper className="bg-sand p-2 sm:p-4 rounded-sm w-full">
                       <div className="flex items-center justify-center mb-4 relative">
                         <p className="text-2xl font-medium select-none">
-                          {isConnected ? "Account" : " Select Wallet"}
+                          {isConnected ? "Account" : "Select Wallet"}
                         </p>
                         <RiCloseLine
-                          className="absolute w-6 right-0 top-0"
+                          className="absolute right-0 top-1/2 transform -translate-y-1/2 w-6 h-6 cursor-pointer"
                           onClick={closeModal}
                         />
                       </div>
-                      <div className="flex items-center justify-center h-full flex-col gap-2 p-8 overflow-scroll">
+                      <div className="flex items-center justify-center h-full flex-col gap-2 px-4 sm:px-6 pb-3 md:py-2 overflow-y-auto max-h-[60vh]">
                         {isConnected && isWrongNetwork && (
                           <Button
-                            variant="black"
+                            variant="silver"
                             className="w-full"
                             onClick={() => switchNetwork?.(TargetChainId)}
                           >
@@ -185,12 +182,12 @@ function ConnectButton() {
                                   rounded="2xl"
                                   onClick={() => connect({ connector })}
                                   variant="black"
-                                  className="w-full h-full flex flex-row justify-start pt-2 pb-2"
+                                  className="w-full h-full flex flex-row justify-start pt-2 pb-2 !px-2 sm:!px-4"
                                 >
-                                  <div className="rounded-sm bg-white flex flex-row justify-center items-center p-2">
+                                  <div className="rounded-sm bg-white flex flex-row justify-center items-center p-1">
                                     <WalletIcon
                                       id={connector.id}
-                                      className="h-16 w-16"
+                                      className="h-8 w-8 lg:h-10 lg:w-10"
                                       // style={{ maxWidth: "100%" }}
                                     />
                                   </div>
@@ -198,7 +195,7 @@ function ConnectButton() {
                                     style={{ marginLeft: "auto" }}
                                     className="basis-4/5 flex-row items-center justify-center"
                                   >
-                                    <span className="text-xl">
+                                    <span className="text-lg md:text-xl">
                                       {connector.name}
                                       {!connector.ready && " (unsupported)"}
                                       {isLoading &&


### PR DESCRIPTION
Added in aload of responsiveness into the modal so it renders in smaller screens such as macbook pro and mobile

Before
<img width="1890" alt="image" src="https://github.com/user-attachments/assets/c0037967-4b42-46da-9296-81c234cb2eeb">
<img width="491" alt="image" src="https://github.com/user-attachments/assets/fd1737a9-39c1-4c97-8ead-e119e09f97ca">

After
<img width="1901" alt="image" src="https://github.com/user-attachments/assets/2ce25f4a-1fba-44cf-92fe-0591915cd384">
<img width="528" alt="image" src="https://github.com/user-attachments/assets/60c570d0-c001-43fc-a779-3aa34e4102ae">
